### PR TITLE
Statistics: fix node count

### DIFF
--- a/src/components/statistics/index.js
+++ b/src/components/statistics/index.js
@@ -12,7 +12,7 @@ class Statistics extends Component {
             <Wrapper>
                 <StatisticsWrapper>
                     <Statistic>
-                        <Number>{this.props.totalStakedNodes}</Number>
+                        <Number>5000&plus;</Number>
                         <Description>Total Staked Nodes</Description>
                     </Statistic>
                     <Statistic>

--- a/src/views/home/index.js
+++ b/src/views/home/index.js
@@ -29,7 +29,6 @@ class Home extends React.Component {
       latestBlocks: [],
       latestTransactions: [],
       totalApps: 0,
-      totalNodes: 0,
       totalTokens: 0,
       showMessage: false,
       transactions: [],
@@ -106,10 +105,6 @@ class Home extends React.Component {
           }
         });
       }
-    });
-
-    dataSource.getNodes().then((nodes) => {
-      this.setState({ totalNodes: nodes });
     });
   }
 
@@ -204,7 +199,6 @@ class Home extends React.Component {
 
   render() {
     const {
-      totalNodes,
       showMessage,
       totalTokens,
       totalApps,
@@ -225,7 +219,6 @@ class Home extends React.Component {
         <Search handler={this.showMessage} />
 
         <Statistics
-          totalStakedNodes={totalNodes}
           totalStaked={totalTokens}
           totalStakedApps={totalApps}
         />


### PR DESCRIPTION
Makes it static with the copy "5000+" nodes, instead of the incorrect number pocketJS is returning.